### PR TITLE
Bug in fortnml

### DIFF
--- a/bin/fortnml
+++ b/bin/fortnml
@@ -136,6 +136,6 @@ if __name__ == "__main__":
     nml.overWriteNamelist()
   elif not opt.quiet:
     if opt.thisrecord:
-      sys.stdout(nml.printNamelist(opt.thisrecord, sorted=opt.sort))
+      sys.stdout.write(nml.printNamelist(opt.thisrecord, sorted=opt.sort))
     else:
-      sys.stdout(nml.printNamelist(sorted=opt.sort))
+      sys.stdout.write(nml.printNamelist(sorted=opt.sort))


### PR DESCRIPTION
A fecha de 20-3-2017, el fortnml instalado dentro del paquete de wrf4g incluye un bug.

En las líneas 139 y 141 debe aparecer: sys.stdout.write(...